### PR TITLE
Fix runtime errors and add pyarrow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ optuna
 joblib
 lightgbm
 tqdm
+pyarrow


### PR DESCRIPTION
## Summary
- add missing pyarrow dependency
- handle datetime month rounding by using `to_period('M')`
- fix LightGBM early stopping during tuning and backtesting

## Testing
- `pip install -r requirements.txt`
- `python nProphet.py` *(interrupted after start)*

------
https://chatgpt.com/codex/tasks/task_e_6854fe817da4832a80246877047b513f